### PR TITLE
Partial fix for a display issue

### DIFF
--- a/src/structuraltools/aisc/shapes.py
+++ b/src/structuraltools/aisc/shapes.py
@@ -23,7 +23,7 @@ from structuraltools.aisc import chapter_B, chapter_F
 from structuraltools.aisc import _shapes_templates as templates
 from structuraltools.template import Result
 from structuraltools.unit import unit, Force, Length, Moment
-from structuraltools.utils import sqrt
+from structuraltools.utils import set_sub_display, sqrt
 
 
 resources = importlib.resources.files("structuraltools.resources")
@@ -80,7 +80,7 @@ class Plate(sections.Rectangle):
         Parameters
         ==========
 
-        b : pint length quantity
+        d : pint length quantity
             Plate width. This is specified at instance initialization to
             make this act more like other shapes.
 
@@ -119,10 +119,12 @@ class Plate(sections.Rectangle):
 
         C_b : float
             Lateral-torsional buckling modification factor"""
-        display = display_options.pop("display", False)
+        sub_options = set_sub_display(display_options)
+
         phi_b = 0.9
+
         if axis == "x":
-            M_n = chapter_F.sec_F11(self, L_b, C_b, **display_options)
+            M_n = chapter_F.sec_F11(self, L_b, C_b, **sub_options)
             template = templates.Plate_moment_capacity_x
         elif axis == "y":
             F_y = self.F_y
@@ -132,7 +134,7 @@ class Plate(sections.Rectangle):
             template = templates.Plate_moment_capacity_y
         else:
             raise ValueError(f"Unsupported axis: {axis}")
-        return template.fill(locals(), phi_b, M_n, display=display, **display_options)
+        return template.fill(locals(), phi_b, M_n, **display_options)
 
 
 class RectHSS(Shape):
@@ -192,15 +194,14 @@ class WideFlange(Shape):
 
         C_b : float
             Lateral-torsional buckling modification factor"""
-        display = display_options.pop("display", False)
+        sub_options = set_sub_display(display_options)
 
         phi_b = 0.9
 
         if self.lamb_w >= chapter_B.table_B4_1b_15_lamb_p(self.E, self.F_y):
             raise ValueError("Only sections with compact webs are supported")
         elif self.lamb_f >= chapter_B.table_B4_1b_10_lamb_p(self.E, self.F_y):
-            M_n = chapter_F.sec_F3(self, L_b, C_b, **display_options)
+            M_n = chapter_F.sec_F3(self, L_b, C_b, **sub_options)
         else:
-            M_n = chapter_F.sec_F2(self, L_b, C_b, **display_options)
-        return templates.WideFlange_moment_capacity.fill(locals(), phi_b, M_n,
-            display=display, **display_options)
+            M_n = chapter_F.sec_F2(self, L_b, C_b, **sub_options)
+        return templates.WideFlange_moment_capacity.fill(locals(), phi_b, M_n, **display_options)

--- a/src/structuraltools/template.py
+++ b/src/structuraltools/template.py
@@ -15,7 +15,7 @@
 
 from string import Template as PyTemplate
 
-from IPython.display import display, Latex, Markdown
+from IPython.display import display_latex, display_markdown
 from numpy import ceil, floor, trunc
 from pint import Quantity
 
@@ -339,11 +339,11 @@ class Template:
         string : str
             String to display"""
         if self.kind == "Math":
-            display(Latex(rf"\begin{{aligned}} {string} \end{{aligned}}"))
+            display_latex(rf"\begin{{aligned}} {string} \end{{aligned}}", raw=True)
         elif self.kind == "Markdown":
-            display(Markdown(string))
+            display_markdown(string, raw=True)
         else:
-            display(Latex(string))
+            display_latex(string, raw=True)
 
     def fill(
             self,

--- a/src/structuraltools/utils.py
+++ b/src/structuraltools/utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+from copy import copy
 import csv
 import warnings
 
@@ -212,3 +212,17 @@ def read_data_table(filepath: str) -> pd.DataFrame:
     data_table = data_table.map(convert_to_unit)
     data_table = data_table.set_index(data_table.columns[0], drop=True)
     return data_table
+
+def set_sub_display(display_options: dict) -> dict:
+    """Returns the display options to use for sub-function calls
+
+    Parameters
+    ==========
+
+    display_options : dict
+        Display options dictionary for the main function"""
+    sub_options = copy(display_options)
+    display = sub_options.pop("display", False)
+    if display:
+        sub_options.update({"return_string": True})
+    return sub_options


### PR DESCRIPTION
The method used to pass display options to functions that were not directly called by the user did (does) not request the calculation string if only the display option is passed. This commit includes a patch fix for a couple of instances, but a more complete fix is needed.